### PR TITLE
 Make object-literal-key-quotes consistent with prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,9 +68,7 @@ module.exports = {
         "no-use-before-declare": false,
         "no-var-keyword": true,
         "no-var-requires": true,
-        "object-literal-key-quotes": {
-            options: ["consistent-as-needed"],
-        },
+        "object-literal-key-quotes": [true, "as-needed"],
         "object-literal-shorthand": true,
         "object-literal-sort-keys": false,
         "one-line": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vanillaforums/tslint-config",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "description": "The Vanilla Forums TSLint config.",
     "main": "index.js",
     "repository": "git@github.com:vanilla/tslint-config.git",


### PR DESCRIPTION
The `object-literal-key-quotes` key quotes did not match the automatically formatted output from prettier, and would issue a warning from prettier's default output. This PR makes them consistent.